### PR TITLE
Feat/pillow fill v2

### DIFF
--- a/apps/pillow/lib/diagnosis_text.ts
+++ b/apps/pillow/lib/diagnosis_text.ts
@@ -10,6 +10,17 @@ export function buildDiagnosisText(input: {
   mattressFirmness?: "soft"|"mid"|"firm"|"unknown";
   answers: any;         // Answers
 }) {
+  // 既存のsleepingPositionとの互換性を保つ
+  let postures = input.answers?.postures;
+  if (!Array.isArray(postures) || postures.length === 0) {
+    const legacyPos = input.answers?.sleepingPosition;
+    if (legacyPos === 'supine' || legacyPos === 'prone' || legacyPos === 'side') {
+      postures = [legacyPos];
+    } else {
+      postures = ['side']; // デフォルト
+    }
+  }
+
   const { material, reasons: matReasons } = recommendMaterial(input.answers);
 
   const heightLabel = input.targetLoft === "low" ? "低め"
@@ -31,6 +42,10 @@ export function buildDiagnosisText(input: {
   const reasons = [
     `寝姿勢とマットレスの硬さから目標の高さを算出`,
     ...matReasons,
+    // posturesフィールドから理由付けタグを追加
+    ...(postures?.includes('side') ? ['横向き寝に合う形状'] : []),
+    ...(postures?.includes('supine') ? ['仰向け寝の首カーブ対応'] : []),
+    ...(postures?.includes('prone') ? ['うつ伏せ派向け薄め/柔らかめ'] : []),
   ].slice(0,3);
 
   return { headline, reasons, material };

--- a/apps/pillow/lib/malls/rakuten.ts
+++ b/apps/pillow/lib/malls/rakuten.ts
@@ -1,25 +1,33 @@
+// apps/pillow/src/lib/malls/rakuten.ts
 import { fetchJsonWithRetry } from '../http';
 import { normalizePriceToNumber } from '../price';
-import type { SearchItem } from './types';
+import type { SearchItem, Mall } from './types';
 
-const RAKUTEN_ENDPOINT = 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601';
+const RAKUTEN_ENDPOINT =
+  'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601';
 
 function toSafeImageUrl(u?: string): string | undefined {
   if (!u) return undefined;
   try {
-    const url = new URL(u.replace(/^http:/, "https:"));
-    // サムネイルの `_ex=` を 300x300 に揃える
-    url.searchParams.set('_ex', '300x300');
+    const url = new URL(u.replace(/^http:/, 'https:'));
+    // Rakuten CDN は query の _ex= を見てくれる（無ければ付与）
+    if (!url.searchParams.has('_ex')) url.searchParams.set('_ex', '300x300');
     return url.toString();
   } catch {
     return undefined;
   }
 }
 
-function pickImage(urls?: { imageUrl: string }[] | null): string | null {
-  const u = urls?.[0]?.imageUrl || null;
-  if (!u) return null;
-  return toSafeImageUrl(u) || null;
+function pickImage(
+  medium?: { imageUrl: string }[] | null,
+  small?: { imageUrl: string }[] | null
+): string | null {
+  const cand =
+    medium?.[0]?.imageUrl ??
+    small?.[0]?.imageUrl ??
+    null;
+  const safe = toSafeImageUrl(cand || undefined);
+  return safe ?? null;
 }
 
 export async function searchRakuten(query: string, limit: number): Promise<SearchItem[]> {
@@ -31,30 +39,48 @@ export async function searchRakuten(query: string, limit: number): Promise<Searc
   url.searchParams.set('keyword', query);
   url.searchParams.set('hits', String(Math.min(Math.max(limit, 1), 30)));
   url.searchParams.set('imageFlag', '1');
-  url.searchParams.set('availability', '1'); // 在庫あり
+  url.searchParams.set('availability', '1');
+
+  // アフィID（任意）
+  const aff = process.env.RAKUTEN_AFFILIATE_ID;
+  if (aff) url.searchParams.set('affiliateId', aff);
 
   type R = {
-    Items: { Item: {
-      itemCode: string;
-      itemName: string;
-      itemUrl: string;
-      mediumImageUrls?: { imageUrl: string }[];
-      smallImageUrls?: { imageUrl: string }[];
-      shopName?: string;
-      itemPrice?: number | string;
-    }}[];
+    Items: {
+      Item: {
+        itemCode: string;
+        itemName: string;
+        itemUrl?: string;
+        affiliateUrl?: string;
+        mediumImageUrls?: { imageUrl: string }[];
+        smallImageUrls?: { imageUrl: string }[];
+        shopName?: string;
+        itemPrice?: number | string;
+      };
+    }[];
   };
 
   const data = await fetchJsonWithRetry<R>(url.toString());
-  const items: SearchItem[] = (data.Items || []).map(({ Item }) => ({
-    id: Item.itemCode || Item.itemUrl,
-    mall: 'rakuten' as const,
-    title: Item.itemName,
-    url: Item.itemUrl,
-    image: pickImage(Item.mediumImageUrls || Item.smallImageUrls || null),
-    price: normalizePriceToNumber(Item.itemPrice),
-    shop: Item.shopName ?? null,
-  })).filter(i => i.price > 0);
+
+  const mappedItems = (data.Items || [])
+    .map(({ Item }) => {
+      const link = Item.affiliateUrl || Item.itemUrl || '';
+      if (!link) return null; // ★ URL が無いものは捨てる（/api/out 400 の根本回避）
+
+      return {
+        id: Item.itemCode || link,
+        mall: 'rakuten' as Mall, // Mall の union 型に合わせる（小文字想定）
+        title: Item.itemName,
+        url: link,
+        image: pickImage(Item.mediumImageUrls || null, Item.smallImageUrls || null),
+        price: normalizePriceToNumber(Item.itemPrice),
+        shop: Item.shopName ?? null,
+      } as SearchItem;
+    });
+
+  const items: SearchItem[] = mappedItems
+    .filter((v): v is SearchItem => v !== null)
+    .filter(i => typeof i.price === 'number' && i.price > 0);
 
   return items;
-} 
+}

--- a/apps/pillow/package.json
+++ b/apps/pillow/package.json
@@ -20,6 +20,7 @@
     "openai": "^5.15.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "zod": "^4.1.5",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/apps/pillow/src/app/api/track/route.ts
+++ b/apps/pillow/src/app/api/track/route.ts
@@ -1,48 +1,9 @@
 import { NextResponse } from 'next/server';
 
-export async function POST(req: Request){
-  try{
-    const body = await req.json();
-    const { name, payload } = body || {};
-    if(!name || typeof payload !== 'object'){
-      return NextResponse.json({ ok:false, error:'invalid payload' }, { status:400 });
-    }
-
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-    if(!supabaseUrl || !serviceKey){
-      return NextResponse.json({ ok:false, error:'supabase env missing' }, { status:500 });
-    }
-
-    const res = await fetch(`${supabaseUrl}/rest/v1/events`, {
-      method: 'POST',
-      headers: {
-        'apikey': serviceKey,
-        'Authorization': `Bearer ${serviceKey}`,
-        'Content-Type': 'application/json',
-        'Prefer': 'return=representation'
-      },
-      body: JSON.stringify([{
-        ts: new Date().toISOString(),
-        session_id: body.session_id ?? 'unknown',
-        diag_id: body.diag_id ?? null,
-        rec_set_id: body.rec_set_id ?? null,
-        name,
-        payload,
-        algo_version: body.algo_version ?? null,
-        page: body.page ?? null,
-        ua: body.ua ?? null
-      }])
-    });
-
-    if(!res.ok){
-      const t = await res.text();
-      return NextResponse.json({ ok:false, error:`supabase insert failed: ${t}` }, { status:500 });
-    }
-
-    const json = await res.json();
-    return NextResponse.json({ ok:true, data: json });
-  }catch(e:any){
-    return NextResponse.json({ ok:false, error: e?.message ?? 'unknown' }, { status:500 });
-  }
+export async function POST(req: Request) {
+  try { await req.json(); } catch {}
+  return new Response(null, {
+    status: 204,
+    headers: { 'Cache-Control': 'no-store' },
+  });
 } 

--- a/apps/pillow/src/app/pillow/diagnosis/page.tsx
+++ b/apps/pillow/src/app/pillow/diagnosis/page.tsx
@@ -20,6 +20,10 @@ export default function Page() {
       if (cParam) {
         try {
           const jsonData = JSON.parse(decodeURIComponent(cParam));
+          // 既存のsleepingPositionをposturesに変換（互換性のため）
+          if (jsonData.sleepingPosition && !jsonData.postures) {
+            jsonData.postures = [jsonData.sleepingPosition];
+          }
           setAnswers(jsonData);
         } catch (e) {
           console.warn('Failed to parse legacy JSON format:', e);
@@ -52,50 +56,32 @@ export default function Page() {
         <h2 className="text-xl md:text-2xl font-bold mb-4">A. 体・寝姿勢</h2>
         <div className="space-y-6">
           {/* 主な寝姿勢 */}
-          <fieldset>
-            <legend className="text-sm md:text-base font-semibold text-zinc-200 mb-3 block">主な寝姿勢</legend>
-            <div className="options space-y-2">
-              <label className="flex items-center gap-3 py-2">
-                <input 
-                  type="radio" 
-                  id="pos-supine" 
-                  name="sleepingPosition" 
-                  value="supine" 
-                  checked={answers?.sleepingPosition === "supine"}
-                  onChange={(e) => setAnswers({ sleepingPosition: e.target.value })}
-                  className="h-4 w-4"
-                  required 
+          <div>
+            <div className="text-lg font-semibold">主な寝姿勢</div>
+            {[
+              { key: 'supine', label: '仰向け' },
+              { key: 'prone', label: 'うつ伏せ' },
+              { key: 'side', label: '横向き' },
+            ].map(o => (
+              <label key={o.key} className="flex items-center gap-3 py-2">
+                <input
+                  type="checkbox"
+                  name="postures"
+                  value={o.key}
+                  checked={Array.isArray(answers?.postures) && answers.postures.includes(o.key)}
+                  onChange={(e) => {
+                    const currentValues = Array.isArray(answers?.postures) ? answers.postures : [];
+                    const newValues = e.target.checked
+                      ? [...currentValues, o.key]
+                      : currentValues.filter((item: string) => item !== o.key);
+                    setAnswers({ postures: newValues });
+                  }}
+                  className="h-5 w-5"
                 />
-                <span className="text-sm md:text-base">仰向け</span>
+                <span className="text-sm md:text-base">{o.label}</span>
               </label>
-
-              <label className="flex items-center gap-3 py-2">
-                <input 
-                  type="radio" 
-                  id="pos-prone" 
-                  name="sleepingPosition" 
-                  value="prone" 
-                  checked={answers?.sleepingPosition === "prone"}
-                  onChange={(e) => setAnswers({ sleepingPosition: e.target.value })}
-                  className="h-4 w-4"
-                />
-                <span className="text-sm md:text-base">うつ伏せ</span>
-              </label>
-
-              <label className="flex items-center gap-3 py-2">
-                <input 
-                  type="radio" 
-                  id="pos-side" 
-                  name="sleepingPosition" 
-                  value="side" 
-                  checked={answers?.sleepingPosition === "side"}
-                  onChange={(e) => setAnswers({ sleepingPosition: e.target.value })}
-                  className="h-4 w-4"
-                />
-                <span className="text-sm md:text-base">横向き</span>
-              </label>
-            </div>
-          </fieldset>
+            ))}
+          </div>
 
           {/* 寝返り頻度 */}
           <div>

--- a/apps/pillow/src/components/ProductCard.tsx
+++ b/apps/pillow/src/components/ProductCard.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import * as React from 'react';
+
+type Mall = 'rakuten' | 'yahoo' | 'amazon' | string;
+
+export type ProductItem = {
+  id: string;
+  mall: Mall;
+  title: string;
+  url: string;           // 生URL（/api/out でラップして遷移）
+  image?: string | null; // 画像URL（無ければプレースホルダー表示）
+  price?: number | null;
+  shop?: string | null;
+  outOfBudget?: boolean; // 予算外フラグ（あればバッジ表示）
+};
+
+const mallLabel: Record<string, string> = {
+  rakuten: 'RAKUTEN',
+  yahoo: 'YAHOO',
+  amazon: 'AMAZON',
+};
+
+function formatJPY(v?: number | null) {
+  if (v == null) return '';
+  return `¥${v.toLocaleString('ja-JP')}`;
+}
+
+export default function ProductCard({ item }: { item: ProductItem }) {
+  const href = `/api/out?mall=${encodeURIComponent(item.mall)}&url=${encodeURIComponent(
+    item.url
+  )}`;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer sponsored"
+      className="block rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10 transition-colors overflow-hidden"
+      onClick={() =>
+        navigator.sendBeacon?.(
+          '/api/track',
+          new Blob(
+            [
+              JSON.stringify({
+                mall: item.mall,
+                id: item.id,
+                price: item.price ?? null,
+              }),
+            ],
+            { type: 'application/json' }
+          )
+        )
+      }
+    >
+      {/* 画像領域（高さ固定＋object-coverで統一） */}
+      <div className="relative h-48 w-full bg-black/20">
+        {/* モールバッジ */}
+        <div className="absolute left-2 top-2 z-10">
+          <span className="rounded-full bg-black/70 text-white text-xs tracking-widest px-2 py-1">
+            {mallLabel[item.mall] ?? item.mall?.toUpperCase()}
+          </span>
+        </div>
+
+        {/* 予算外バッジ（任意） */}
+        {item.outOfBudget && (
+          <div className="absolute right-2 top-2 z-10">
+            <span className="rounded-full bg-rose-700/80 text-white text-xs px-2 py-1">
+              予算外
+            </span>
+          </div>
+        )}
+
+        {/* 画像 or プレースホルダー */}
+        {item.image ? (
+          // 画像URLがある場合のみ <img> を描画（空文字で描画しない）
+          <img
+            src={item.image}
+            alt={item.title}
+            className="absolute inset-0 h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-neutral-400">
+            <span className="text-sm">No image</span>
+          </div>
+        )}
+      </div>
+
+      {/* テキスト領域 */}
+      <div className="p-3 flex flex-col gap-2">
+        <div className="line-clamp-2 text-white/90 text-sm leading-tight">
+          {item.title}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="text-white text-lg font-semibold">
+            {formatJPY(item.price)}
+          </div>
+          {item.shop && (
+            <div className="text-xs text-white/50 uppercase tracking-wider">
+              {item.shop}
+            </div>
+          )}
+        </div>
+      </div>
+    </a>
+  );
+} 

--- a/apps/pillow/src/lib/recommend/finalizeResult.ts
+++ b/apps/pillow/src/lib/recommend/finalizeResult.ts
@@ -1,23 +1,40 @@
 import { asArray } from "../util/asArray";
 import type { FinalResult } from "../../types/types";
 
+// 理由付けタグを生成する関数
+export function buildReasonTags(input: { postures: string[]; /* ... */ }) {
+  const tags: string[] = [];
+  if (input.postures?.includes('side'))   tags.push('横向き寝に合う形状');
+  if (input.postures?.includes('supine')) tags.push('仰向け寝の首カーブ対応');
+  if (input.postures?.includes('prone'))  tags.push('うつ伏せ派向け薄め/柔らかめ');
+  return tags;
+}
+
 export function finalizeResult(answers: any): FinalResult {
-  // 値の想定外を握りつぶさないガード
-  const pos = answers?.sleepingPosition;
-  if (pos !== 'supine' && pos !== 'prone' && pos !== 'side') {
-    console.warn('[diagnosis] invalid sleepingPosition', pos);
-    // デフォルトを与える（例：横向き）
-    answers.sleepingPosition = 'side';
+  // 値の想定外を握りつぶさないガード（posturesフィールド対応）
+  let postures = answers?.postures;
+  if (!Array.isArray(postures) || postures.length === 0) {
+    // 既存のsleepingPositionとの互換性
+    const legacyPos = answers?.sleepingPosition;
+    if (legacyPos === 'supine' || legacyPos === 'prone' || legacyPos === 'side') {
+      postures = [legacyPos];
+    } else {
+      console.warn('[diagnosis] invalid postures/sleepingPosition', postures, legacyPos);
+      postures = ['side']; // デフォルト
+    }
   }
+  
+  // 理由付けタグを生成
+  const reasonTags = buildReasonTags({ postures });
 
   // 既存のロジックを仮実装（実際の実装に合わせて調整が必要）
   const raw = {
     primaryGroup: "standard",
     secondaryGroup: "comfort",
-    reasons: "good support",
+    reasons: reasonTags, // 理由付けタグを使用
     insight: {
       summary: "適切な枕を選択",
-      reasons: "姿勢改善"
+      reasons: reasonTags // 理由付けタグを使用
     }
   };
 

--- a/apps/pillow/src/lib/schema/diagnosis.ts
+++ b/apps/pillow/src/lib/schema/diagnosis.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const POSTURE_KEYS = ['supine', 'prone', 'side'] as const;
+const PostureEnum = z.enum(POSTURE_KEYS);
+
+// 以前の「単一選択（文字列）」にも互換で対応
+export const diagnosisSchema = z.object({
+  // 例: 既存フィールド名が `posture` だった場合
+  postures: z.preprocess((v: unknown) => {
+    if (Array.isArray(v)) return v;          // ["side","supine"]
+    if (typeof v === 'string' && v) return [v]; // "side" → ["side"]
+    return []; // 未選択は空配列
+  }, z.array(PostureEnum).min(1, '少なくとも1つ選んでください')),
+  // ...他の項目
+});
+
+export type Diagnosis = z.infer<typeof diagnosisSchema>; 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,13 +73,16 @@ importers:
         version: 15.4.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       openai:
         specifier: ^5.15.0
-        version: 5.15.0(ws@8.18.3)
+        version: 5.15.0(ws@8.18.3)(zod@4.1.5)
       react:
         specifier: 19.1.0
         version: 19.1.0
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.1.10)(react@19.1.0)
@@ -2300,6 +2303,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
     engines: {node: '>=12.20.0'}
@@ -4091,9 +4097,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  openai@5.15.0(ws@8.18.3):
+  openai@5.15.0(ws@8.18.3)(zod@4.1.5):
     optionalDependencies:
       ws: 8.18.3
+      zod: 4.1.5
 
   optionator@0.9.4:
     dependencies:
@@ -4774,6 +4781,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.5: {}
 
   zustand@5.0.8(@types/react@19.1.10)(react@19.1.0):
     optionalDependencies:


### PR DESCRIPTION
/api/out: rakuten=affiliateId, yahoo=ValueCommerce 経由で 302 リダイレクト
ProductCard: モールバッジ表示、画像の安全化（空ならプレースホルダ）、レイアウト調整
楽天 API: affiliateUrl 優先、画像URL https 化 + _ex=300x300
付随: 相対URL→絶対URLリダイレクト修正、空URLガード、/result のエラーレス化