### PR TITLE
feat: 商品除外条件を拡張

### DIFF
--- a/apps/pillow/lib/filters.ts
+++ b/apps/pillow/lib/filters.ts
@@ -30,3 +30,28 @@ export function isFurusato(
   if (/ふるさと納税/.test(sh)) return true;
   return false;
 }
+
+// 新しい除外条件の判定関数
+export function isBabyPillowTitle(title?: string): boolean {
+  if (!title) return false;
+  const t = title.toLowerCase();
+  return /(ベビー|赤ちゃん|新生児|乳児|子供|キッズ|ジュニア|幼児|ドーナツ枕|ベビー枕|赤ちゃん枕)/i.test(t);
+}
+
+export function isFutonSetTitle(title?: string): boolean {
+  if (!title) return false;
+  const t = title.toLowerCase();
+  return /(布団セット|寝具セット|枕付き|枕込み|セット)/i.test(t);
+}
+
+export function isHugPillowTitle(title?: string): boolean {
+  if (!title) return false;
+  const t = title.toLowerCase();
+  return /(抱き枕|抱きまくら|ボディピロー|ボディ枕|抱き|ボディ)/i.test(t);
+}
+
+export function isSpecialUseTitle(title?: string): boolean {
+  if (!title) return false;
+  const t = title.toLowerCase();
+  return /(医療用|介護用|リハビリ|治療用|車用|旅行用|キャンプ用|アウトドア用)/i.test(t);
+}

--- a/apps/pillow/src/app/api/search-cross/filters.ts
+++ b/apps/pillow/src/app/api/search-cross/filters.ts
@@ -1,14 +1,18 @@
-// Business rules for item filtering (枕カバー/ふるさと納税) - 2025-09 policy
+// Business rules for item filtering (枕カバー/ふるさと納税/ベビー用/布団セット/抱き枕) - 2025-09 policy
 import type { SearchItem } from '../../../../lib/malls/types';
 
 export type WithFlags<T> = T & {
   flags?: {
     isCover?: boolean;
     isFurusato?: boolean;
+    isBabyPillow?: boolean;
+    isFutonSet?: boolean;
+    isHugPillow?: boolean;
+    isSpecialUse?: boolean;
   };
 };
 
-// 正規表現
+// 既存の正規表現
 const RE_COVER_TITLE = /(枕カバー|まくらカバー|ピローケース|pillow\s*case)/i;
 // URLは誤爆防止のため "pillow-?case|pillow-?cover" 周辺に限定
 const RE_COVER_URL = /(pillow-?case|pillow-?cover|\/pillowcase|\/pillow-cover)/i;
@@ -17,6 +21,12 @@ const RE_FURUSATO_TITLE = /(ふるさと納税|返礼品|寄付|寄附)/i;
 // NOTE: furunavi が正。furanavi は誤り
 const RE_FURUSATO_URL = /(furusato|furunavi|satofull|\/furusato)/i;
 const RE_FURUSATO_SHOP = /(楽天ふるさと納税|ふるさと納税)/i;
+
+// 新しい除外条件の正規表現
+const RE_BABY_PILLOW = /(ベビー|赤ちゃん|新生児|乳児|子供|キッズ|ジュニア|幼児|ドーナツ枕|ベビー枕|赤ちゃん枕)/i;
+const RE_FUTON_SET = /(布団セット|寝具セット|枕付き|枕込み|セット)/i;
+const RE_HUG_PILLOW = /(抱き枕|抱きまくら|ボディピロー|ボディ枕|抱き|ボディ)/i;
+const RE_SPECIAL_USE = /(医療用|介護用|リハビリ|治療用|車用|旅行用|キャンプ用|アウトドア用)/i;
 
 export function isCover(item: SearchItem): boolean {
   const t = item.title ?? '';
@@ -31,6 +41,26 @@ export function isFurusato(item: SearchItem): boolean {
   return RE_FURUSATO_TITLE.test(t) || RE_FURUSATO_URL.test(u) || RE_FURUSATO_SHOP.test(s);
 }
 
+export function isBabyPillow(item: SearchItem): boolean {
+  const t = item.title ?? '';
+  return RE_BABY_PILLOW.test(t);
+}
+
+export function isFutonSet(item: SearchItem): boolean {
+  const t = item.title ?? '';
+  return RE_FUTON_SET.test(t);
+}
+
+export function isHugPillow(item: SearchItem): boolean {
+  const t = item.title ?? '';
+  return RE_HUG_PILLOW.test(t);
+}
+
+export function isSpecialUse(item: SearchItem): boolean {
+  const t = item.title ?? '';
+  return RE_SPECIAL_USE.test(t);
+}
+
 export function annotateFlags<T extends SearchItem>(item: T): WithFlags<T> {
   return {
     ...item,
@@ -38,17 +68,25 @@ export function annotateFlags<T extends SearchItem>(item: T): WithFlags<T> {
       ...(item as any).flags,
       isCover: isCover(item),
       isFurusato: isFurusato(item),
+      isBabyPillow: isBabyPillow(item),
+      isFutonSet: isFutonSet(item),
+      isHugPillow: isHugPillow(item),
+      isSpecialUse: isSpecialUse(item),
     },
   };
 }
 
-// 仕様：枕カバー=常時除外、ふるさと納税=常時除外（SSOT）
+// 仕様：枕カバー/ふるさと納税/ベビー用/布団セット/抱き枕/特殊用途=常時除外（SSOT）
 export function applyFilters<T extends SearchItem>(items: T[]): WithFlags<T>[] {
   const out: WithFlags<T>[] = [];
   for (const raw of items) {
     const item = annotateFlags(raw);
     if (item.flags?.isCover) continue;
     if (item.flags?.isFurusato) continue;
+    if (item.flags?.isBabyPillow) continue;
+    if (item.flags?.isFutonSet) continue;
+    if (item.flags?.isHugPillow) continue;
+    if (item.flags?.isSpecialUse) continue;
     out.push(item);
   }
   return out;

--- a/apps/pillow/src/app/pillow/result/page.tsx
+++ b/apps/pillow/src/app/pillow/result/page.tsx
@@ -19,7 +19,7 @@ import { resolveBandId } from "@/lib/budget";
 import { GROUP_LABEL } from "@/lib/ui/labels";
 import ProductCard, { ProductItem } from '@/components/ProductCard';
 import type { SearchItem } from "../../../../lib/malls/types";
-import { isCover, isFurusato } from '@/app/api/search-cross/filters';
+import { isCover, isFurusato, isBabyPillow, isFutonSet, isHugPillow, isSpecialUse } from '@/app/api/search-cross/filters';
 
 const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === '1';
 
@@ -309,7 +309,7 @@ export default function ResultPage() {
         let items = dedupeAndPickCheapest([...(real.items || []), ...mock]);
 
         // 念のためクライアント側でもフィルタ（保険）
-        items = items.filter((i: SearchItem) => !isCover(i) && !isFurusato(i));
+        items = items.filter((i: SearchItem) => !isCover(i) && !isFurusato(i) && !isBabyPillow(i) && !isFutonSet(i) && !isHugPillow(i) && !isSpecialUse(i));
 
         if (items.length > 0) {
           // ユーザーの予算帯キー
@@ -354,7 +354,7 @@ export default function ResultPage() {
           const fallbackItems = await fetch(`${baseUrl}/api/search-cross?q=枕&limit=${limit}`, { cache: 'no-store' }).then(r => r.json());
           if (!mounted) return;
           
-          let fallbackFiltered = fallbackItems.filter((i: SearchItem) => !isCover(i) && !isFurusato(i));
+          let fallbackFiltered = fallbackItems.filter((i: SearchItem) => !isCover(i) && !isFurusato(i) && !isBabyPillow(i) && !isFutonSet(i) && !isHugPillow(i) && !isSpecialUse(i));
           const userBand: BudgetBandKey = (answers?.budget ?? "3k-6k") as BudgetBandKey;
           const decoratedItems = decorateItemsWithPriceAndBudget(fallbackFiltered, userBand);
           


### PR DESCRIPTION
- ベビー・子供用枕の除外機能を追加
- 布団セットの除外機能を追加
- 抱き枕の除外機能を追加
- 特殊用途枕（医療用、車用等）の除外機能を追加
- 成人用枕に特化した商品推薦を実現

除外対象:
- ベビー|赤ちゃん|新生児|乳児|子供|キッズ|ジュニア|幼児|ドーナツ枕|ベビー枕|赤ちゃん枕
- 布団セット|寝具セット|枕付き|枕込み|セット
- 抱き枕|抱きまくら|ボディピロー|ボディ枕|抱き|ボディ
- 医療用|介護用|リハビリ|治療用|車用|旅行用|キャンプ用|アウトドア用